### PR TITLE
[FIX] Service calls are now compatible with foxglove_bridge from the sdk repository

### DIFF
--- a/src/Impl.ts
+++ b/src/Impl.ts
@@ -333,15 +333,23 @@ export class Impl {
     const name =
       'schemaName' in channelOrService
         ? channelOrService.schemaName
-        : channelOrService.type;
+        : 'response' in channelOrService
+          ? channelOrService.response.schemaName
+          : undefined;
     const schemaEncoding =
       'schemaEncoding' in channelOrService
         ? channelOrService.schemaEncoding
-        : undefined;
+        : 'response' in channelOrService
+          ? channelOrService.response.schemaEncoding
+          : undefined;
     const schema =
       'schema' in channelOrService
         ? channelOrService.schema
-        : channelOrService.responseSchema;
+        : 'response' in channelOrService
+          ? channelOrService.response.schema
+          : 'responseSchema' in channelOrService
+            ? channelOrService.responseSchema
+            : undefined;
     return (
       this.#messageReaders.get(name) ??
       (() => {
@@ -366,11 +374,17 @@ export class Impl {
     const schemaEncoding =
       'schemaEncoding' in channelOrService
         ? channelOrService.schemaEncoding
-        : undefined;
+        : 'request' in channelOrService
+          ? channelOrService.request.schemaEncoding
+          : undefined;
     const schema =
       'schema' in channelOrService
         ? channelOrService.schema
-        : channelOrService.requestSchema;
+        : 'request' in channelOrService
+          ? channelOrService.request.schema
+          : 'requestSchema' in channelOrService
+            ? channelOrService.requestSchema
+            : undefined;
     return (
       this.#messageWriters.get(name) ??
       (() => {


### PR DESCRIPTION
Service calls are fixed for up-to-date version (3.2.2) while still keeping compatibility with the old version (0.8.5)

## Types of PR
- [x] Bugfix

## Description
Service calls were failing on my side when foxglove_bridge from the [foxglove-sdk repository](https://github.com/foxglove/foxglove-sdk) was being used due to schema change on the communication between the bridge and the client. With this this patch, both versions work as expected.

## How to review this PR
Clone and build recent bridge from the [foxglove_sdk](https://github.com/foxglove/foxglove-sdk), call minimal service and test the example js client, errors like "undefined has no `split`" received. When patched roslib.foxglove.js is used, service calls and regular channels both work correctly.

```shell
ros2 run examples_rclcpp_minimal_service service_main
```
```shell
ros2 launch foxglove_bridge foxglove_bridge_launch.xml
```
```html
<script src="roslib.foxglove.js"></script>
<script>
  const ros = new ROSLIB.Ros({ url: "ws://localhost:8765" });

  ros.on("connection", () => console.log("connected"));
  // First, we create a Service client with details of the service's name and service type.
  var addTwoIntsClient = new ROSLIB.Service({
    ros: ros,
    name: "/add_two_ints",
    serviceType: "example_interfaces/srv/AddTwoInts",
  });

  var request = {
    a: 1,
    b: 2,
  };

  addTwoIntsClient.callService(request, function (result) {
    console.log(
      "Result for service call on " +
        addTwoIntsClient.name +
        ": " +
        result.sum,
    );
  });
</script>

```

## Others